### PR TITLE
Make to_string_with_precision respect precision argument for a_value 0

### DIFF
--- a/include/utils/parser.h
+++ b/include/utils/parser.h
@@ -47,10 +47,13 @@ static inline float get_safe_float_range(std::string val)
 template <typename T>
 std::string to_string_with_precision(const T a_value, const int n = 4)
 {
-	if (a_value <= 0.01f && a_value >= -0.01f)
-		return "0.0000";
 	std::ostringstream out;
-	out << std::fixed << std::setprecision(n) << a_value;
+	if (a_value <= 0.01f && a_value >= -0.01f) {
+		out << std::fixed << std::setprecision(n) << 0.0f;
+	}
+	else {
+		out << std::fixed << std::setprecision(n) << a_value;
+	}
 	return out.str();
 }
 


### PR DESCRIPTION
When using `to_string_with_precision` for a value close enough to 0, the return value is "0.0000" no matter what the precision is set. This PR changes the behavior to use the same code path for both 0 and non-0 values, only with a different argument. This makes the precision be respected in case of argument roughly equal to 0.